### PR TITLE
Merge data-validation into data-validators category

### DIFF
--- a/_data/tools.yml
+++ b/_data/tools.yml
@@ -862,7 +862,7 @@
 - name: tsoa
   category:
     - server
-    - data-validation
+    - data-validators
   language: Node.js / TypeScript
   link: https://github.com/lukeautry/tsoa
   github: https://github.com/lukeautry/tsoa


### PR DESCRIPTION
The `data-validators` is listed in the `[categories.yml](https://github.com/apisyouwonthate/openapi.tools/blob/main/_data/categories.yml)` file, but `data-validation` not. I think it's better to use just one of them.